### PR TITLE
Allow re-install app with different signatures and permission declared

### DIFF
--- a/app/src/main/java/toolkit/coderstory/CorePatchForR.java
+++ b/app/src/main/java/toolkit/coderstory/CorePatchForR.java
@@ -17,6 +17,7 @@ import java.lang.reflect.Member;
 import java.lang.reflect.Method;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.zip.ZipEntry;
@@ -251,6 +252,30 @@ public class CorePatchForR extends XposedHelper implements IXposedHookLoadPackag
                     }
                 }
             }
+        }
+
+        var keySetManagerClass = findClass("com.android.server.pm.KeySetManagerService", loadPackageParam.classLoader);
+        if (keySetManagerClass != null) {
+            var shouldBypass = new ThreadLocal<Boolean>();
+            hookAllMethods(keySetManagerClass, "shouldCheckUpgradeKeySetLocked", new XC_MethodHook() {
+                @Override
+                protected void afterHookedMethod(MethodHookParam param) throws Throwable {
+                    if (prefs.getBoolean("digestCreak", true) && Arrays.stream(Thread.currentThread().getStackTrace()).anyMatch((o) -> "preparePackageLI".equals(o.getMethodName()))) {
+                        shouldBypass.set(true);
+                        param.setResult(true);
+                    } else {
+                        shouldBypass.set(false);
+                    }
+                }
+            });
+            hookAllMethods(keySetManagerClass, "checkUpgradeKeySetLocked", new XC_MethodHook() {
+                @Override
+                protected void afterHookedMethod(MethodHookParam param) throws Throwable {
+                    if (prefs.getBoolean("digestCreak", true) && shouldBypass.get()) {
+                        param.setResult(true);
+                    }
+                }
+            });
         }
     }
 


### PR DESCRIPTION
Allow packages to redefine its own permissions, without throwing `INSTALL_FAILED_DUPLICATE_PERMISSION` exception when `digestCreak` is enabled.