### PR TITLE
Android 9 support

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,7 +14,7 @@ android {
     buildToolsVersion = "34.0.0"
     defaultConfig {
         applicationId = "com.coderstory.toolkit"
-        minSdk = 29
+        minSdk = 28
         targetSdk = 34
         versionCode = 2000
         versionName = "4.3"

--- a/app/src/main/java/toolkit/coderstory/MainHook.java
+++ b/app/src/main/java/toolkit/coderstory/MainHook.java
@@ -32,6 +32,7 @@ public class MainHook implements IXposedHookLoadPackage, IXposedHookZygoteInit {
                     new CorePatchForR().handleLoadPackage(lpparam);
                     break;
                 case Build.VERSION_CODES.Q: // 29
+                case Build.VERSION_CODES.P: // 28
                     new CorePatchForQ().handleLoadPackage(lpparam);
                     break;
                 default:
@@ -61,6 +62,7 @@ public class MainHook implements IXposedHookLoadPackage, IXposedHookZygoteInit {
                     new CorePatchForR().initZygote(startupParam);
                     break;
                 case Build.VERSION_CODES.Q: // 29
+                case Build.VERSION_CODES.P: // 28
                     new CorePatchForQ().initZygote(startupParam);
                     break;
                 default:

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1,6 +1,6 @@
 <resources>
     <string name="app_name">Core Patch</string>
-    <string name="module_description">Patch pour Android 10–14</string>
+    <string name="module_description">Patch pour Android 9–14</string>
     <string name="corepatch">Cette version est pour 10–14 uniquement.\nMerci d\’utiliser la dernière version de LSPosed.</string>
     <string name="downgr">Permettre la rétrogradation</string>
     <string name="downgr_summary">Permettre la rétrogradation d\’applications.</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -1,7 +1,7 @@
 <resources>
     <string name="app_name">Core Patch</string>
-    <string name="module_description">Android 10–14 core patch</string>
-    <string name="corepatch">Versi ini adalah untuk Android 10-14 saja.\nHarap gunakan versi LSPosed terbaru.</string>
+    <string name="module_description">Android 9–14 core patch</string>
+    <string name="corepatch">Versi ini adalah untuk Android 9-14 saja.\nHarap gunakan versi LSPosed terbaru.</string>
     <string name="downgr">Izinkan downgrade</string>
     <string name="downgr_summary">Izinkan downgrade aplikasi.</string>
     <string name="authcreak">Matikan verifikasi digest</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <resources>
   <string name="app_name">Core Patch</string>
-  <string name="module_description">Android 10–14 コアパッチ</string>
-  <string name="corepatch">このバージョンは、 Android 10–14 のみで動作します。\nLSPosed の最新版をご利用ください。</string>
+  <string name="module_description">Android 9–14 コアパッチ</string>
+  <string name="corepatch">このバージョンは、 Android 9–14 のみで動作します。\nLSPosed の最新版をご利用ください。</string>
   <string name="downgr">ダウングレードを許可する</string>
   <string name="downgr_summary">アプリのダウングレードを許可します。</string>
   <string name="authcreak">Digest の認証を無効化する</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1,7 +1,7 @@
 <resources>
     <string name="app_name">Core Patch</string>
-    <string name="module_description">Android 10–14 core patch</string>
-    <string name="corepatch">이 버전은 Android 10–14 전용입니다.\nLSPosed의 최신 버전을 사용하십시오.</string>
+    <string name="module_description">Android 9–14 core patch</string>
+    <string name="corepatch">이 버전은 Android 9–14 전용입니다.\nLSPosed의 최신 버전을 사용하십시오.</string>
     <string name="downgr">다운그레이드 허용</string>
     <string name="downgr_summary">애플리케이션 다운그레이드를 허용합니다.</string>
     <string name="authcreak">다이제스트 확인 비활성화</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1,7 +1,7 @@
 <resources>
     <string name="app_name">Core Patch</string>
-    <string name="module_description">Android 10–14 core patch</string>
-    <string name="corepatch">Esta versão é apenas para Android 10–14.\nPor favor, use a versão mais recente do LSPosed.</string>
+    <string name="module_description">Android 9–14 core patch</string>
+    <string name="corepatch">Esta versão é apenas para Android 9–14.\nPor favor, use a versão mais recente do LSPosed.</string>
     <string name="downgr">Permitir downgrade</string>
     <string name="downgr_summary">Permitir downgrade de apps.</string>
     <string name="authcreak">Desativar verificação de integridade</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -7,7 +7,7 @@
   <string name="app_name">Core Patch</string>
   <string name="authcreak">Отключить проверку дайджеста</string>
   <string name="authcreak_summary">Позволяет устанавливать приложения после изменения файла в apk (игнорировать недопустимую ошибку дайджеста).</string>
-  <string name="corepatch">«Эта версия предназначена только для Android 10–14.
+  <string name="corepatch">«Эта версия предназначена только для Android 9–14.
 Пожалуйста, используйте последнюю версию LSPposed. "</string>
   <string name="digestCreak">Отключить сравнение подписей</string>
   <string name="digestCreak_summary">Разрешить переустановку приложения с другими подписями.</string>
@@ -16,7 +16,7 @@
   <string name="enhancedMode">Расширенный режим</string>
   <string name="enhancedMode_summary">Пройдите некоторую проверку в приложении</string>
   <string name="ignore">Игнорировать</string>
-  <string name="module_description">Android 10–14 core patch</string>
+  <string name="module_description">Android 9–14 core patch</string>
   <string name="not_supported">Похоже, вы используете устаревшую версию LSPposed или LSPposed не активирован, пожалуйста, обновите LSPposed или повторите попытку после активации.</string>
   <string name="settings">Настройки</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1,7 +1,7 @@
 <resources>
     <string name="app_name">核心破解</string>
-    <string name="module_description">Android 10–14 核心破解</string>
-    <string name="corepatch">此版本只支持 Android 10–14\n请安装最新版本的 LSPosed 框架，否则功能可能无法正确启用。</string>
+    <string name="module_description">Android 9–14 核心破解</string>
+    <string name="corepatch">此版本只支持 Android 9–14\n请安装最新版本的 LSPosed 框架，否则功能可能无法正确启用。</string>
     <string name="downgr">允许降级安装应用</string>
     <string name="downgr_summary">允许应用在安装新版本的情况下直接覆盖安装旧版本</string>
     <string name="authcreak">禁用软件包管理器签名验证</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">核心修補</string>
-    <string name="module_description">Android 10–14 核心修補</string>
-    <string name="corepatch">此版本只支援 Android 10–14\n請安裝最新版本的 LSPosed 框架，否則功能可能無法正確啟用。</string>
+    <string name="module_description">Android 9–14 核心修補</string>
+    <string name="corepatch">此版本只支援 Android 9–14\n請安裝最新版本的 LSPosed 框架，否則功能可能無法正確啟用。</string>
     <string name="downgr">允許降版安裝應用程式</string>
     <string name="downgr_summary">允許應用程式在安裝新版本的情況下直接覆蓋安裝舊版本</string>
     <string name="authcreak">停用套裝安裝程式簽名驗證</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <resources>
     <string name="app_name">Core Patch</string>
-    <string name="module_description">Android 10–14 core patch</string>
-    <string name="corepatch">This version is for Android 10–14 only.\nPlease use the latest version of the LSPosed.</string>
+    <string name="module_description">Android 9–14 core patch</string>
+    <string name="corepatch">This version is for Android 9–14 only.\nPlease use the latest version of the LSPosed.</string>
     <string name="downgr">Allow downgrade</string>
     <string name="downgr_summary">Allow downgrade applications.</string>
     <string name="authcreak">Disable digest verify</string>


### PR DESCRIPTION
The hooks in CorePatchForQ supported Android 9 (P), but for some reason, the min version was Android 10 (Q). So I added support for Android 9, it worked perfectly on both rooted emulator and phone running Android 9