### PR TITLE
feat: add disabling exact signature check

### DIFF
--- a/app/src/main/java/toolkit/coderstory/CorePatchForQ.java
+++ b/app/src/main/java/toolkit/coderstory/CorePatchForQ.java
@@ -149,5 +149,14 @@ public class CorePatchForQ extends XposedHelper implements IXposedHookLoadPackag
                 "isVerificationEnabled",
                 new ReturnConstant(prefs, "disableVerificationAgent", false)
         );
+
+        // Allow apk splits with different signatures to be installed together
+        hookAllMethods(signingDetails, "signaturesMatchExactly", new XC_MethodHook() {
+            @Override
+            protected void beforeHookedMethod(MethodHookParam param) {
+                if (prefs.getBoolean("exactSigCheck", false))
+                    param.setResult(true);
+            }
+        });
     }
 }

--- a/app/src/main/java/toolkit/coderstory/CorePatchForR.java
+++ b/app/src/main/java/toolkit/coderstory/CorePatchForR.java
@@ -65,6 +65,7 @@ public class CorePatchForR extends XposedHelper implements IXposedHookLoadPackag
             XposedBridge.log("D/" + MainHook.TAG + " downgrade=" + prefs.getBoolean("downgrade", true));
             XposedBridge.log("D/" + MainHook.TAG + " authcreak=" + prefs.getBoolean("authcreak", false));
             XposedBridge.log("D/" + MainHook.TAG + " digestCreak=" + prefs.getBoolean("digestCreak", true));
+            XposedBridge.log("D/" + MainHook.TAG + " exactSigCheck=" + prefs.getBoolean("exactSigCheck", false));
             XposedBridge.log("D/" + MainHook.TAG + " UsePreSig=" + prefs.getBoolean("UsePreSig", false));
             XposedBridge.log("D/" + MainHook.TAG + " bypassBlock=" + prefs.getBoolean("bypassBlock", true));
             XposedBridge.log("D/" + MainHook.TAG + " sharedUser=" + prefs.getBoolean("sharedUser", false));
@@ -405,6 +406,15 @@ public class CorePatchForR extends XposedHelper implements IXposedHookLoadPackag
         );
 
         hookAllMethods(getIsVerificationEnabledClass(loadPackageParam.classLoader), "isVerificationEnabled", new ReturnConstant(prefs, "disableVerificationAgent", false));
+
+        // Allow apk splits with different signatures to be installed together
+        hookAllMethods(signingDetails, "signaturesMatchExactly", new XC_MethodHook() {
+            @Override
+            protected void beforeHookedMethod(MethodHookParam param) {
+                if (prefs.getBoolean("exactSigCheck", false))
+                    param.setResult(true);
+            }
+        });
 
         if (BuildConfig.DEBUG) initializeDebugHook(loadPackageParam);
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,6 +8,8 @@
     <string name="authcreak_summary">Allows install apps after modify file in apk (ignore invalid digest error).</string>
     <string name="digestCreak">Disable compare signatures</string>
     <string name="digestCreak_summary">Allow re-install app with different signatures.</string>
+    <string name="exactSigCheck">Disable exact signature match</string>
+    <string name="exactSigCheck_summary">Disables exact signature match between apks, allowing installs with each apk split having a different signature. Only enable when really needed!</string>
     <string name="UsePreSig">Use installed signatures</string>
     <string name="UsePreSig_summary">Always use signatures from already installed apps when installing.\n This is extremely <b>dangerous</b>.\n Only enable when really needed!</string>
     <string name="settings">Settings</string>

--- a/app/src/main/res/xml/prefs.xml
+++ b/app/src/main/res/xml/prefs.xml
@@ -17,6 +17,11 @@
             android:title="@string/digestCreak"
             android:summary="@string/digestCreak_summary"
             android:defaultValue="true" />
+        <SwitchPreference
+            android:key="exactSigCheck"
+            android:title="@string/exactSigCheck"
+            android:summary="@string/exactSigCheck_summary"
+            android:defaultValue="false"/>
 
         <SwitchPreference
             android:key="UsePreSig"


### PR DESCRIPTION
Typically, installing a split APK enforces that the same signature is present across all of the splits. This adds the option to disable that check to allow installing splits with differing signatures.