### PR TITLE
Remove final modifier to bypass A17 reflection restrictions

### DIFF
--- a/app/src/main/java/toolkit/coderstory/CorePatchForU.java
+++ b/app/src/main/java/toolkit/coderstory/CorePatchForU.java
@@ -1,9 +1,13 @@
 package toolkit.coderstory;
 
-import android.os.Build;
+import static de.robv.android.xposed.XposedHelpers.findField;
+import static de.robv.android.xposed.XposedHelpers.getIntField;
+import static de.robv.android.xposed.XposedHelpers.setIntField;
+
 import android.util.Log;
 
 import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Modifier;
 
 import de.robv.android.xposed.XC_MethodHook;
 import de.robv.android.xposed.XposedBridge;
@@ -24,12 +28,15 @@ public class CorePatchForU extends CorePatchForT {
         }
 
         // https://cs.android.com/android/platform/superproject/+/android-14.0.0_r60:frameworks/base/services/core/java/com/android/server/pm/ReconcilePackageUtils.java;l=61;bpv=1;bpt=0
-        // Android 17 blocks using reflection to modify static final field
-        // Since DP2, instead of throwing java exception, they just let art itself crash
-        // Disable it temporarily till we change hook points
-        if ((Build.VERSION.SDK_INT < Build.VERSION_CODES.BAKLAVA || (Build.VERSION.SDK_INT == Build.VERSION_CODES.BAKLAVA && Build.VERSION.PREVIEW_SDK_INT == 0))
-                && prefs.getBoolean("digestCreak", true) && prefs.getBoolean("sharedUser", false)) {
-            setStaticBooleanField(utilClass, "ALLOW_NON_PRELOADS_SYSTEM_SHAREDUIDS", true);
+        if (prefs.getBoolean("digestCreak", true) && prefs.getBoolean("sharedUser", false)) {
+            try {
+                var field = findField(utilClass, "ALLOW_NON_PRELOADS_SYSTEM_SHAREDUIDS");
+                var accessFlags = getIntField(field, "accessFlags");
+                setIntField(field, "accessFlags", accessFlags & ~Modifier.FINAL);
+                field.set(null, true);
+            } catch (Throwable e) {
+                XposedBridge.log("E/" + MainHook.TAG + " ALLOW_NON_PRELOADS_SYSTEM_SHAREDUIDS failed" + Log.getStackTraceString(e));
+            }
         }
 
         // ee11a9c (Rename AndroidPackageApi to AndroidPackage)


### PR DESCRIPTION
I tested it on 17 Beta 2 and the system_server isn't crashed while booting. Removing the FINAL access flag allows us to set value.